### PR TITLE
Add `coqutil` as dependency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ You will need Coq 8.7, 8.8, or master.
 
 ```
 git clone https://github.com/mit-plv/bbv.git
+git clone https://github.com/mit-plv/coqutil.git
 git clone https://github.com/mit-plv/riscv-coq.git
 make -C bbv
+make -C coqutil
 cd riscv-coq/
 make
 ```


### PR DESCRIPTION
In commit 32572f7 a new dependency got added, but the README.md wasn’t
changed accordingly. This commit adds the missing information.