### PR TITLE
Avoid relying on `Export` bugs

### DIFF
--- a/src/Platform/MetricMinimalMMIO.v
+++ b/src/Platform/MetricMinimalMMIO.v
@@ -17,7 +17,7 @@ Require Import riscv.Platform.MetricLogging.
 Require Import coqutil.Z.Lia.
 Require Import coqutil.Map.Interface.
 Require Import coqutil.Tactics.Tactics.
-
+Import MetricRiscvMachine.
 
 Local Open Scope Z_scope.
 Local Open Scope bool_scope.


### PR DESCRIPTION
See https://github.com/coq/coq/issues/10474 and
https://github.com/coq/coq/issues/10480

This is in preparation for coq/coq#10476 which fixes these two bugs, and is backward compatible (tested on Coq's master).