### PR TITLE
Adapt to https://github.com/coq/coq/pull/19530

### DIFF
--- a/convert-hs-to-coq/CSR_preamble.v
+++ b/convert-hs-to-coq/CSR_preamble.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/convert-hs-to-coq/Decode_preamble.v
+++ b/convert-hs-to-coq/Decode_preamble.v
@@ -1,4 +1,4 @@
-Require Coq.ZArith.BinInt.
+From Coq Require BinInt.
 Local Open Scope Z_scope.
 
 Notation Register := BinInt.Z (only parsing).

--- a/convert-hs-to-coq/Execute_preamble.v
+++ b/convert-hs-to-coq/Execute_preamble.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Examples/Example64Literal.v
+++ b/src/riscv/Examples/Example64Literal.v
@@ -1,11 +1,11 @@
-Require Import Coq.Lists.List.
+From Coq Require Import List.
 Require Import coqutil.Z.Lia.
 Import ListNotations.
 Require Import coqutil.Word.Naive.
 Require Import coqutil.Word.Properties.
 Require Import riscv.Spec.Machine.
 Require Import riscv.Spec.Decode.
-Require Import Coq.ZArith.BinInt. Local Open Scope Z_scope.
+From Coq Require Import BinInt. Local Open Scope Z_scope.
 Require Import riscv.Utility.Utility.
 Require Import riscv.Platform.Memory.
 Require Import riscv.Platform.Minimal.

--- a/src/riscv/Examples/Fib.v
+++ b/src/riscv/Examples/Fib.v
@@ -1,11 +1,11 @@
-Require Import Coq.Lists.List.
+From Coq Require Import List.
 Require Import coqutil.Z.Lia.
 Import ListNotations.
 Require Import coqutil.Word.Naive.
 Require Import coqutil.Word.Properties.
 Require Import riscv.Spec.Machine.
 Require Import riscv.Spec.Decode.
-Require Import Coq.ZArith.BinInt. Local Open Scope Z_scope.
+From Coq Require Import BinInt. Local Open Scope Z_scope.
 Require Import riscv.Utility.Utility.
 Require Import riscv.Platform.Memory.
 Require Import riscv.Platform.Minimal.

--- a/src/riscv/Examples/SMTVerif.v
+++ b/src/riscv/Examples/SMTVerif.v
@@ -1,12 +1,12 @@
-Require Import Coq.Lists.List.
-Require Import Coq.Logic.Classical_Prop.
+From Coq Require Import List.
+From Coq Require Import Classical_Prop.
 Import ListNotations.
 Require Import coqutil.Decidable.
 Require Import coqutil.Word.Naive.
 Require Import riscv.Spec.Machine.
 Require Import riscv.Spec.Decode.
 Require Import riscv.Spec.Execute.
-Require Import Coq.ZArith.BinInt. Local Open Scope Z_scope.
+From Coq Require Import BinInt. Local Open Scope Z_scope.
 Require Import riscv.Utility.Utility.
 Require Import riscv.Utility.PowerFunc.
 Require Import riscv.Utility.Monads. Import MonadNotations.

--- a/src/riscv/Examples/WMMFree.v
+++ b/src/riscv/Examples/WMMFree.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List. Import ListNotations.
+From Coq Require Import List. Import ListNotations.
 Require Import coqutil.Decidable.
 Require Import coqutil.Tactics.Tactics.
 Require Import coqutil.Tactics.Simp.
@@ -16,11 +16,11 @@ Require Import coqutil.Map.Z_keyed_SortedListMap.
 Require Import coqutil.Map.OfFunc.
 Require Import coqutil.Word.Properties.
 Require Import coqutil.Z.prove_Zeq_bitwise.
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import riscv.Utility.PowerFunc.
-Require Import Coq.Logic.FunctionalExtensionality.
-Require Import Coq.Logic.PropExtensionality.
-Require Import Coq.derive.Derive.
+From Coq Require Import FunctionalExtensionality.
+From Coq Require Import PropExtensionality.
+From Coq Require Import Derive.
 Require Import riscv.Spec.Decode.
 
 (* sub-relation *)

--- a/src/riscv/Platform/FE310ExtSpec.v
+++ b/src/riscv/Platform/FE310ExtSpec.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import coqutil.Map.Interface.
 Require Import riscv.Utility.Utility.
 Require Import riscv.Platform.MinimalMMIO.

--- a/src/riscv/Platform/LogInstructionTrace.v
+++ b/src/riscv/Platform/LogInstructionTrace.v
@@ -1,5 +1,5 @@
-Require Import Coq.ZArith.ZArith.
-Require Import Coq.Lists.List.
+From Coq Require Import ZArith.
+From Coq Require Import List.
 Require Import riscv.Utility.Monads. Import StateAbortFailOperations.
 Require Import riscv.Utility.MonadNotations.
 Require Import riscv.Spec.Decode.

--- a/src/riscv/Platform/Memory.v
+++ b/src/riscv/Platform/Memory.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List.
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import List.
+From Coq Require Import ZArith.
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Word.Properties.
 Require Import coqutil.Word.Bitwidth.

--- a/src/riscv/Platform/MetricLogging.v
+++ b/src/riscv/Platform/MetricLogging.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import coqutil.Z.Lia.
 
 Section Riscv.

--- a/src/riscv/Platform/MetricMaterializeRiscvProgram.v
+++ b/src/riscv/Platform/MetricMaterializeRiscvProgram.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import coqutil.Word.Interface coqutil.Word.Bitwidth.
 Require Import riscv.Utility.Monads.
 Require Import riscv.Utility.FreeMonad.

--- a/src/riscv/Platform/MetricMinimal.v
+++ b/src/riscv/Platform/MetricMinimal.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Monads. Import OStateOperations.
 Require Import riscv.Utility.MonadNotations.
 Require Import riscv.Spec.Decode.
@@ -16,8 +16,8 @@ Require Import riscv.Platform.MetricLogging.
 Require Import riscv.Spec.MetricPrimitives.
 Require Import coqutil.Z.Lia.
 Require Import coqutil.Z.Lia.
-Require Import Coq.Logic.FunctionalExtensionality.
-Require Import Coq.Logic.PropExtensionality.
+From Coq Require Import FunctionalExtensionality.
+From Coq Require Import PropExtensionality.
 
 Local Open Scope Z_scope.
 Local Open Scope bool_scope.

--- a/src/riscv/Platform/MetricMinimalMMIO.v
+++ b/src/riscv/Platform/MetricMinimalMMIO.v
@@ -1,6 +1,6 @@
-Require Import Coq.ZArith.ZArith.
-Require Import Coq.Logic.FunctionalExtensionality.
-Require Import Coq.Logic.PropExtensionality.
+From Coq Require Import ZArith.
+From Coq Require Import FunctionalExtensionality.
+From Coq Require Import PropExtensionality.
 Require Import riscv.Utility.Monads.
 Require Import riscv.Utility.MonadNotations.
 Require Import riscv.Spec.Decode.
@@ -8,7 +8,7 @@ Require Import riscv.Spec.Machine.
 Require Import riscv.Utility.Utility.
 Require Import riscv.Spec.Primitives.
 Require Import riscv.Spec.MetricPrimitives.
-Require Import Coq.Lists.List. Import ListNotations.
+From Coq Require Import List. Import ListNotations.
 Require Export riscv.Platform.RiscvMachine.
 Require Export riscv.Platform.MetricRiscvMachine.
 Require Import riscv.Platform.MinimalMMIO.

--- a/src/riscv/Platform/MetricRiscvMachine.v
+++ b/src/riscv/Platform/MetricRiscvMachine.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Coq Require Import String.
 Require Import coqutil.Map.Interface.
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Word.LittleEndian.

--- a/src/riscv/Platform/MetricSane.v
+++ b/src/riscv/Platform/MetricSane.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Coq Require Import List.
 Require Import coqutil.Map.Interface coqutil.Map.Properties.
 Require Import coqutil.Tactics.Tactics.
 Require Import riscv.Spec.Machine.

--- a/src/riscv/Platform/Minimal.v
+++ b/src/riscv/Platform/Minimal.v
@@ -1,7 +1,7 @@
-Require Import Coq.ZArith.ZArith.
-Require Import Coq.Lists.List.
-Require Import Coq.Logic.FunctionalExtensionality.
-Require Import Coq.Logic.PropExtensionality.
+From Coq Require Import ZArith.
+From Coq Require Import List.
+From Coq Require Import FunctionalExtensionality.
+From Coq Require Import PropExtensionality.
 Require Import riscv.Utility.Monads. Import OStateOperations.
 Require Import riscv.Utility.MonadNotations.
 Require Import riscv.Spec.Decode.

--- a/src/riscv/Platform/MinimalCSRs.v
+++ b/src/riscv/Platform/MinimalCSRs.v
@@ -1,6 +1,6 @@
-Require Import Coq.ZArith.ZArith. Local Open Scope Z_scope.
-Require Import Coq.Strings.String.
-Require Import Coq.Lists.List. Import ListNotations.
+From Coq Require Import ZArith. Local Open Scope Z_scope.
+From Coq Require Import String.
+From Coq Require Import List. Import ListNotations.
 Require Import coqutil.Tactics.Tactics.
 Require Import riscv.Spec.Machine.
 Require Import riscv.Platform.Memory.

--- a/src/riscv/Platform/MinimalCSRsDet.v
+++ b/src/riscv/Platform/MinimalCSRsDet.v
@@ -1,5 +1,5 @@
-Require Import Coq.ZArith.ZArith.
-Require Import Coq.Lists.List.
+From Coq Require Import ZArith.
+From Coq Require Import List.
 Require Import riscv.Utility.Monads. Import StateAbortFailOperations.
 Require Import riscv.Utility.MonadNotations.
 Require Import riscv.Spec.Decode.

--- a/src/riscv/Platform/MinimalLogging.v
+++ b/src/riscv/Platform/MinimalLogging.v
@@ -1,5 +1,5 @@
-Require Import Coq.ZArith.BinInt.
-Require Import Coq.Strings.String.
+From Coq Require Import BinInt.
+From Coq Require Import String.
 Require Import riscv.Utility.Monads. Import OStateOperations.
 Require Import riscv.Utility.MonadNotations.
 Require Import riscv.Spec.Decode.
@@ -8,7 +8,7 @@ Require Import riscv.Spec.Machine.
 Require Import riscv.Spec.Execute.
 Require Import riscv.Utility.PowerFunc.
 Require Import riscv.Utility.Utility.
-Require Import Coq.Lists.List. Import ListNotations.
+From Coq Require Import List. Import ListNotations.
 Require Import riscv.Platform.Minimal.
 Require Import coqutil.Map.Interface.
 

--- a/src/riscv/Platform/MinimalMMIO.v
+++ b/src/riscv/Platform/MinimalMMIO.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import String.
+From Coq Require Import ZArith.
 Require Import riscv.Utility.Monads.
 Require Import riscv.Utility.MonadNotations.
 Require Export riscv.Utility.FreeMonad.
@@ -7,7 +7,7 @@ Require Import riscv.Spec.Decode.
 Require Import riscv.Spec.Machine.
 Require Import riscv.Utility.Utility.
 Require Import riscv.Spec.Primitives.
-Require Import Coq.Lists.List. Import ListNotations.
+From Coq Require Import List. Import ListNotations.
 Require Import coqutil.Datatypes.List.
 Require Import coqutil.Datatypes.ListSet.
 Require Export riscv.Platform.RiscvMachine.

--- a/src/riscv/Platform/MinimalMMIO_Post.v
+++ b/src/riscv/Platform/MinimalMMIO_Post.v
@@ -1,12 +1,12 @@
-Require Import Coq.Strings.String.
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import String.
+From Coq Require Import ZArith.
 Require Import riscv.Utility.Monads.
 Require Import riscv.Utility.MonadNotations.
 Require Import riscv.Spec.Decode.
 Require Import riscv.Spec.Machine.
 Require Import riscv.Utility.Utility.
 Require Import riscv.Spec.Primitives.
-Require Import Coq.Lists.List. Import ListNotations.
+From Coq Require Import List. Import ListNotations.
 Require Import coqutil.Datatypes.List.
 Require Import coqutil.Datatypes.ListSet.
 Require Export riscv.Platform.RiscvMachine.

--- a/src/riscv/Platform/RiscvMachine.v
+++ b/src/riscv/Platform/RiscvMachine.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String.
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import String.
+From Coq Require Import BinInt.
 Require Import coqutil.Map.Interface.
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Word.LittleEndian.

--- a/src/riscv/Platform/Run.v
+++ b/src/riscv/Platform/Run.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import coqutil.Word.LittleEndian.
 Require Import riscv.Utility.Monads.
 Require Import riscv.Utility.MonadNotations.

--- a/src/riscv/Platform/Sane.v
+++ b/src/riscv/Platform/Sane.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Coq Require Import List.
 Require Import coqutil.Map.Interface coqutil.Map.Properties.
 Require Import coqutil.Tactics.Tactics.
 Require Import riscv.Spec.Machine.

--- a/src/riscv/Proofs/DecodeByExtension.v
+++ b/src/riscv/Proofs/DecodeByExtension.v
@@ -1,5 +1,5 @@
-Require Export Coq.ZArith.ZArith.
-Require Export Coq.Lists.List. Import ListNotations.
+From Coq Require Export ZArith.
+From Coq Require Export List. Import ListNotations.
 Require Import coqutil.Tactics.Tactics.
 Require Import coqutil.Tactics.rdelta.
 Require Import coqutil.Tactics.destr.

--- a/src/riscv/Proofs/DecodeEncodeProver.v
+++ b/src/riscv/Proofs/DecodeEncodeProver.v
@@ -1,5 +1,5 @@
-Require Export Coq.ZArith.ZArith.
-Require Export Coq.Lists.List. Import ListNotations.
+From Coq Require Export ZArith.
+From Coq Require Export List. Import ListNotations.
 Require Export riscv.Spec.Decode.
 Require Export riscv.Utility.Encode.
 Require Export riscv.Utility.Utility.

--- a/src/riscv/Proofs/EncodeBound.v
+++ b/src/riscv/Proofs/EncodeBound.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import riscv.Spec.Decode.
 Require Import riscv.Utility.Encode.
 Require Import riscv.Utility.Utility.

--- a/src/riscv/Proofs/EncodeDecode.v
+++ b/src/riscv/Proofs/EncodeDecode.v
@@ -1,5 +1,5 @@
-Require Export Coq.ZArith.ZArith.
-Require Export Coq.Lists.List. Import ListNotations.
+From Coq Require Export ZArith.
+From Coq Require Export List. Import ListNotations.
 Require Import coqutil.Tactics.rdelta.
 Require Import coqutil.Tactics.destr.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/InstructionSetOrder.v
+++ b/src/riscv/Proofs/InstructionSetOrder.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith. Open Scope Z_scope.
+From Coq Require Import ZArith. Open Scope Z_scope.
 Require Import coqutil.Z.Lia.
 Require Import riscv.Spec.Decode.
 Require Import riscv.Utility.Encode.

--- a/src/riscv/Proofs/VerifyDecode.v
+++ b/src/riscv/Proofs/VerifyDecode.v
@@ -1,5 +1,5 @@
-Require Export Coq.ZArith.ZArith.
-Require Export Coq.Lists.List. Import ListNotations.
+From Coq Require Export ZArith.
+From Coq Require Export List. Import ListNotations.
 Require Import coqutil.Tactics.rdelta.
 Require Import coqutil.Tactics.destr.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_Fence.v
+++ b/src/riscv/Proofs/invert_encode_Fence.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_FenceI.v
+++ b/src/riscv/Proofs/invert_encode_FenceI.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_I.v
+++ b/src/riscv/Proofs/invert_encode_I.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_I_shift_57.v
+++ b/src/riscv/Proofs/invert_encode_I_shift_57.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_I_shift_66.v
+++ b/src/riscv/Proofs/invert_encode_I_shift_66.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_I_system.v
+++ b/src/riscv/Proofs/invert_encode_I_system.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_R.v
+++ b/src/riscv/Proofs/invert_encode_R.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_R_atomic.v
+++ b/src/riscv/Proofs/invert_encode_R_atomic.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_S.v
+++ b/src/riscv/Proofs/invert_encode_S.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_SB.v
+++ b/src/riscv/Proofs/invert_encode_SB.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_U.v
+++ b/src/riscv/Proofs/invert_encode_U.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Proofs/invert_encode_UJ.v
+++ b/src/riscv/Proofs/invert_encode_UJ.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Z.prove_Zeq_bitwise.

--- a/src/riscv/Spec/CSR.v
+++ b/src/riscv/Spec/CSR.v
@@ -7,19 +7,19 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.
 
 (* Converted imports: *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Utility.Utility.
 
 (* Converted type declarations: *)

--- a/src/riscv/Spec/CSRField.v
+++ b/src/riscv/Spec/CSRField.v
@@ -7,12 +7,12 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Spec/CSRFile.v
+++ b/src/riscv/Spec/CSRFile.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import coqutil.Map.Interface.
 Require Import coqutil.Map.SortedList.
 Require Import coqutil.Z.Lia.

--- a/src/riscv/Spec/CSRGetSet.v
+++ b/src/riscv/Spec/CSRGetSet.v
@@ -7,19 +7,19 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.
 
 (* Converted imports: *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import Monads.
 Require Spec.CSR.
 Require Spec.CSRField.

--- a/src/riscv/Spec/CSRSpec.v
+++ b/src/riscv/Spec/CSRSpec.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Spec/Decode.v
+++ b/src/riscv/Spec/Decode.v
@@ -7,12 +7,12 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Coq.ZArith.BinInt.
+From Coq Require BinInt.
 Local Open Scope Z_scope.
 
 Notation Register := BinInt.Z (only parsing).
@@ -22,9 +22,9 @@ Notation Opcode := BinInt.Z (only parsing).
 
 (* Converted imports: *)
 
-Require Coq.Init.Datatypes.
-Require Coq.Lists.List.
-Require Import Coq.ZArith.BinInt.
+From Coq Require Datatypes.
+From Coq Require List.
+From Coq Require Import BinInt.
 Require Utility.Utility.
 
 (* Converted type declarations: *)

--- a/src/riscv/Spec/ExecuteA.v
+++ b/src/riscv/Spec/ExecuteA.v
@@ -7,12 +7,12 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Spec/ExecuteA64.v
+++ b/src/riscv/Spec/ExecuteA64.v
@@ -7,12 +7,12 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Spec/ExecuteCSR.v
+++ b/src/riscv/Spec/ExecuteCSR.v
@@ -7,19 +7,19 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.
 
 (* Converted imports: *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Machine.
 Require Import Monads.
 Require Spec.CSR.

--- a/src/riscv/Spec/ExecuteI.v
+++ b/src/riscv/Spec/ExecuteI.v
@@ -7,12 +7,12 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Spec/ExecuteI64.v
+++ b/src/riscv/Spec/ExecuteI64.v
@@ -7,12 +7,12 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Spec/ExecuteM.v
+++ b/src/riscv/Spec/ExecuteM.v
@@ -7,12 +7,12 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Spec/ExecuteM64.v
+++ b/src/riscv/Spec/ExecuteM64.v
@@ -7,12 +7,12 @@ Set Maximal Implicit Insertion.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.
 
-Require Coq.Program.Tactics.
-Require Coq.Program.Wf.
+From Coq.Program Require Tactics.
+From Coq.Program Require Wf.
 
 (* Preamble *)
 
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Local Open Scope Z.
 Require Import riscv.Utility.Utility.
 Local Open Scope alu_scope.

--- a/src/riscv/Spec/Machine.v
+++ b/src/riscv/Spec/Machine.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import riscv.Utility.Monads.
 Require riscv.Utility.MonadNotations.
 Require Import riscv.Utility.Utility.

--- a/src/riscv/Spec/MetricPrimitives.v
+++ b/src/riscv/Spec/MetricPrimitives.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List.
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import List.
+From Coq Require Import BinInt.
 Require Import coqutil.Map.Interface.
 Require Import riscv.Utility.Monads.
 Require Import riscv.Utility.Utility.

--- a/src/riscv/Spec/Primitives.v
+++ b/src/riscv/Spec/Primitives.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List.
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import List.
+From Coq Require Import BinInt.
 Require Import coqutil.Map.Interface.
 Require Import riscv.Utility.Monads.
 Require Import riscv.Utility.Utility.

--- a/src/riscv/Spec/PseudoInstructions.v
+++ b/src/riscv/Spec/PseudoInstructions.v
@@ -1,6 +1,6 @@
 Require Import riscv.Spec.Decode.
 Require Import riscv.Spec.Machine.
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 
 Open Scope Z_scope.
 

--- a/src/riscv/Utility/DefaultMemImpl32.v
+++ b/src/riscv/Utility/DefaultMemImpl32.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import coqutil.Z.Lia.
 Require Import coqutil.Word.Interface coqutil.Word.Properties coqutil.Word.Naive.
 Require Import coqutil.Map.Interface.

--- a/src/riscv/Utility/DefaultMemImpl64.v
+++ b/src/riscv/Utility/DefaultMemImpl64.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import coqutil.Z.Lia.
 Require Import coqutil.Word.Interface coqutil.Word.Properties coqutil.Word.Naive.
 Require Import coqutil.Map.Interface.

--- a/src/riscv/Utility/Encode.v
+++ b/src/riscv/Utility/Encode.v
@@ -1,5 +1,5 @@
 (* Need to define Register *)
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import riscv.Spec.Decode.
 Require Import riscv.Utility.Utility.
 

--- a/src/riscv/Utility/ExtensibleRecords.v
+++ b/src/riscv/Utility/ExtensibleRecords.v
@@ -1,5 +1,5 @@
-Require Import Coq.PArith.BinPos.
-Require Import Coq.Lists.List. Import ListNotations.
+From Coq Require Import BinPos.
+From Coq Require Import List. Import ListNotations.
 
 Module natmap. Section __.
   Context {V: Type}.

--- a/src/riscv/Utility/FreeMonad.v
+++ b/src/riscv/Utility/FreeMonad.v
@@ -1,5 +1,5 @@
-Require Import Coq.Logic.FunctionalExtensionality.
-Require Import Coq.Logic.PropExtensionality.
+From Coq Require Import FunctionalExtensionality.
+From Coq Require Import PropExtensionality.
 Require Import riscv.Utility.Monads.
 
 Module free.

--- a/src/riscv/Utility/JMonad.v
+++ b/src/riscv/Utility/JMonad.v
@@ -1,5 +1,5 @@
 (* monads implemented in terms of fmap & join & return instead of bind & return *)
-Require Import Coq.Lists.List.
+From Coq Require Import List.
 
 Class Monad(M: Type -> Type) := mkMonad {
   ret: forall {A}, A -> M A;

--- a/src/riscv/Utility/MMIOTrace.v
+++ b/src/riscv/Utility/MMIOTrace.v
@@ -1,4 +1,4 @@
-Require Import Coq.Strings.String.
+From Coq Require Import String.
 
 Definition MMIOAction: Type := string.
 Definition MMInput: MMIOAction := "MMInput"%string.

--- a/src/riscv/Utility/MkMachineWidth.v
+++ b/src/riscv/Utility/MkMachineWidth.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Z.BitOps.
 Require Import coqutil.Word.LittleEndian.

--- a/src/riscv/Utility/MonadT.v
+++ b/src/riscv/Utility/MonadT.v
@@ -1,4 +1,4 @@
-Require Import Coq.Lists.List.
+From Coq Require Import List.
 
 Class Monad(M: Type -> Type) := mkMonad {
   Bind: forall {A B}, M A -> (A -> M B) -> M B;

--- a/src/riscv/Utility/MonadTests.v
+++ b/src/riscv/Utility/MonadTests.v
@@ -1,5 +1,5 @@
-Require Import Coq.Lists.List. Import ListNotations.
-Require Import Coq.Arith.PeanoNat.
+From Coq Require Import List. Import ListNotations.
+From Coq Require Import PeanoNat.
 
 
 Class Monad(M: Type -> Type) := mkMonad {

--- a/src/riscv/Utility/Monads.v
+++ b/src/riscv/Utility/Monads.v
@@ -1,6 +1,6 @@
-Require Import Coq.Logic.FunctionalExtensionality.
-Require Import Coq.Logic.PropExtensionality.
-Require Import Coq.Lists.List.
+From Coq Require Import FunctionalExtensionality.
+From Coq Require Import PropExtensionality.
+From Coq Require Import List.
 
 Class Monad(M: Type -> Type) := mkMonad {
   Bind: forall {A B}, M A -> (A -> M B) -> M B;

--- a/src/riscv/Utility/RegisterNameNotations.v
+++ b/src/riscv/Utility/RegisterNameNotations.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Declare Custom Entry register_name.
 
 Notation "'zero'" :=   0%Z (in custom register_name).

--- a/src/riscv/Utility/RegisterNames.v
+++ b/src/riscv/Utility/RegisterNames.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import riscv.Spec.Decode.
 
 Local Open Scope Z_scope.

--- a/src/riscv/Utility/StringRecords.v
+++ b/src/riscv/Utility/StringRecords.v
@@ -1,5 +1,5 @@
-Require Import Coq.Strings.String. Open Scope string_scope.
-Require Import Coq.Lists.List. Import ListNotations.
+From Coq Require Import String. Open Scope string_scope.
+From Coq Require Import List. Import ListNotations.
 
 Local Set Universe Polymorphism.
 

--- a/src/riscv/Utility/Tactics.v
+++ b/src/riscv/Utility/Tactics.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 
 (* Like "pose proof" but only if we don't yet have this hypothesis *)
 Tactic Notation "unique" "pose" "proof" constr(defn) :=

--- a/src/riscv/Utility/Utility.v
+++ b/src/riscv/Utility/Utility.v
@@ -1,6 +1,6 @@
-Require Export Coq.ZArith.BinIntDef.
-Require Import Coq.ZArith.ZArith.
-Require Import Coq.setoid_ring.Ring_theory.
+From Coq Require Export BinIntDef.
+From Coq Require Import ZArith.
+From Coq Require Import Ring_theory.
 Require Export coqutil.Word.Interface.
 Require Export coqutil.Word.Bitwidth.
 Require Export coqutil.Byte.

--- a/src/riscv/Utility/Words32Naive.v
+++ b/src/riscv/Utility/Words32Naive.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import coqutil.Z.Lia.
 Require Import coqutil.Word.Properties.
 Require Import coqutil.Word.Bitwidth.

--- a/src/riscv/Utility/Words64Naive.v
+++ b/src/riscv/Utility/Words64Naive.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+From Coq Require Import BinInt.
 Require Import coqutil.Z.Lia.
 Require Import coqutil.Word.Naive.
 Require Import coqutil.Word.Properties.

--- a/src/riscv/Utility/bverify.v
+++ b/src/riscv/Utility/bverify.v
@@ -1,11 +1,11 @@
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import ZArith.
 Require Import riscv.Spec.Decode.
 Require Import riscv.Utility.Encode.
 Require Import riscv.Utility.Utility.
 
 (* same verification functions as in Encode, but computable: *)
 
-Require Import Coq.derive.Derive.
+From Coq Require Import Derive.
 
 Lemma andb_spec: forall P Q p q,
     Bool.reflect P p ->

--- a/src/riscv/Utility/nat_div_mod_to_quot_rem.v
+++ b/src/riscv/Utility/nat_div_mod_to_quot_rem.v
@@ -1,5 +1,5 @@
-Require Import Coq.Arith.PeanoNat.
-Require Import Coq.ZArith.ZArith.
+From Coq Require Import PeanoNat.
+From Coq Require Import ZArith.
 Require Import riscv.Utility.Tactics.
 Require Import coqutil.Z.Lia.
 


### PR DESCRIPTION
Adapt to https://github.com/coq/coq/pull/19530
This is an adaptation in anticipation of the day the temporary backward compatibility introduced in the upstream PR will be removed (probably a few years in the future).
Merging this is not required for the upstream PR, you can do whatever you want with it.
